### PR TITLE
chore(infra): rename repo to drkostas.github.io

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
-# CLAUDE.md (Draft for portfolio-v2 repo)
+# CLAUDE.md
 
 ## Project Overview
 
-This is the new portfolio + blog for Kostas Georgiou (gkos.dev), built with Astro. It replaces the previous VSCode-themed Next.js portfolio.
+This is the portfolio + blog for Kostas Georgiou (gkos.dev), built with Astro. It replaced the previous VSCode-themed Next.js portfolio.
 
-**Live site (old, still running):** https://gkos.dev (served by Vercel from `drkostas/vscode-portfolio`)
-**This repo:** `drkostas/portfolio-v2` (private until launch)
-**Target URL:** https://gkos.dev (will switch Vercel to this repo when ready)
+**Live site:** https://gkos.dev (served by Vercel from `drkostas/drkostas.github.io`)
+**Previous portfolio (archived):** `drkostas/vscode-portfolio`
+**Local folder:** still `portfolio-v2/` (GitHub name and disk name don't have to match).
 
 ## About the Owner
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# portfolio-v2
+# drkostas.github.io
 
 The source for [gkos.dev](https://gkos.dev), my personal portfolio + blog. Built with Astro, deployed on Vercel.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "portfolio-v2",
+  "name": "drkostas.github.io",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "portfolio-v2",
+      "name": "drkostas.github.io",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "portfolio-v2",
+  "name": "drkostas.github.io",
   "type": "module",
   "version": "0.0.1",
   "private": true,

--- a/scripts/smoke-test-prod.mjs
+++ b/scripts/smoke-test-prod.mjs
@@ -1,0 +1,49 @@
+import { chromium } from "playwright";
+const BASE = "https://portfolio-v2-one-pied.vercel.app";
+const ROUTES = [
+  { path: "/", title: "Home" },
+  { path: "/about", title: "About" },
+  { path: "/blog", title: "Blog list" },
+  { path: "/blog/hello-world", title: "Blog post" },
+  { path: "/blog/how-i-got-here", title: "Blog post 2" },
+  { path: "/projects", title: "Projects" },
+  { path: "/publications", title: "Publications" },
+  { path: "/inspirations", title: "Inspirations" },
+  { path: "/contact", title: "Contact" },
+  { path: "/stats", title: "Stats" },
+  { path: "/community-wall", title: "Community wall" },
+  { path: "/changelog", title: "Changelog" },
+  { path: "/workbench", title: "Workbench" },
+  { path: "/explore", title: "Explore (coming soon)" },
+  { path: "/anything-random-route-xyz", title: "404 fallback" },
+];
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 1 });
+const page = await ctx.newPage();
+const results = [];
+for (const { path, title } of ROUTES) {
+  const errors = [];
+  const consoleErrs = [];
+  page.removeAllListeners("pageerror");
+  page.removeAllListeners("console");
+  page.on("pageerror", (e) => errors.push("ERR: " + e.message.substring(0, 200)));
+  page.on("console", (m) => { if (m.type() === "error") consoleErrs.push(m.text().substring(0, 200)); });
+  try {
+    const r = await page.goto(BASE + path, { waitUntil: "domcontentloaded", timeout: 20000 });
+    const status = r ? r.status() : -1;
+    await page.waitForTimeout(1500);
+    const h1 = await page.evaluate(() => document.querySelector("h1")?.textContent?.substring(0, 80) ?? "(no h1)");
+    results.push({ path, title, status, h1, errors: errors.length, consoleErrs: consoleErrs.length });
+  } catch (err) {
+    results.push({ path, title, status: -1, h1: "(load failed)", error: err.message.substring(0, 100) });
+  }
+}
+await browser.close();
+console.log("\n=== Smoke test results ===\n");
+for (const r of results) {
+  const flag = r.status >= 200 && r.status < 400 ? "✓" : "✗";
+  console.log(`${flag} ${r.status}  ${r.path.padEnd(35)} h1:${(r.h1 || "").padEnd(40)}  err:${r.errors}/${r.consoleErrs}`);
+}
+const failed = results.filter((r) => r.status === -1 || r.status >= 500);
+const hasErrors = results.filter((r) => (r.errors ?? 0) > 0 || (r.consoleErrs ?? 0) > 0);
+console.log(`\nfailed: ${failed.length} · routes with JS errors: ${hasErrors.length}\n`);

--- a/src/data/siteMetadata.ts
+++ b/src/data/siteMetadata.ts
@@ -6,7 +6,7 @@ export const siteMetadata = {
     "ML engineer with a PhD. Research, side projects, and open source on self-supervised learning, LLMs, and computer vision.",
   language: "en-us",
   siteUrl: "https://gkos.dev",
-  siteRepo: "https://github.com/drkostas/portfolio-v2",
+  siteRepo: "https://github.com/drkostas/drkostas.github.io",
   avatarImage: "/kostas_neurips_square.jpg",
   socialBanner: "/og-image.png",
   email: "mailto:gkos.mldev@gmail.com",


### PR DESCRIPTION
## Summary

Swapped names with the old VSCode portfolio: this repo is now `drkostas/drkostas.github.io`, the old one moved to `drkostas/vscode-portfolio`. GitHub redirects keep old URLs working.

## What changed inside the repo

- README + CLAUDE.md headers
- `package.json` + `package-lock.json` `name` field
- `siteMetadata.siteRepo` (footer GitHub link)
- New `scripts/smoke-test-prod.mjs` (used to verify all routes before flipping public — kept for future migrations)

## What did NOT change

- `IP_HASH_SALT` default in `reactions.ts` — changing it would invalidate existing reaction dedupe hashes
- Local checkout folder name (`portfolio-v2/` on disk) — disk name and GitHub name don't have to match
- The Vercel custom domains gkos.dev and www.gkos.dev — still attached, still serving

## Vercel side

The Vercel project was also renamed to `drkostas-github-io`. Deploys keep working because Vercel tracks the GitHub integration by repo ID, not by name.

## Verified

- \`https://gkos.dev\` → 308 → \`https://www.gkos.dev\` → 200, still serves this Astro build
- \`git remote -v\` already points at new URL